### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : zipcpu
+      VLNV : zipcpu::zipcpu
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: zipcpu
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130_div $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : zipcpu
+      VLNV : zipcpu::zipcpu
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: zipcpu
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,8 @@
+set ::env(CLOCK_PORT) "i_clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(GLB_RT_ADJUSTMENT) 0.15
+
+set ::env(CLOCK_PERIOD) "19.09"
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(FP_CORE_UTIL) 40
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]

--- a/zipcpu.core
+++ b/zipcpu.core
@@ -1,0 +1,51 @@
+CAPI=2:
+
+name : zipcpu::zipcpu:0
+
+filesets:
+  core:
+    files:
+      - rtl/cpudefs.v : {is_include_file : true}
+      - rtl/core/axiicache.v
+      - rtl/core/cpuops.v
+      - rtl/core/dblfetch.v
+      - rtl/core/dcache.v
+      - rtl/core/div.v
+      - rtl/core/idecode.v
+      - rtl/core/iscachable.v
+      - rtl/core/memops.v
+      - rtl/core/mpyop.v
+      - rtl/core/pfcache.v
+      - rtl/core/pipefetch.v
+      - rtl/core/pipemem.v
+      - rtl/core/prefetch.v
+      - rtl/core/slowmpy.v
+      - rtl/core/zipcpu.v
+    file_type : verilogSource
+
+  ex:
+    files:
+      - rtl/ex/busdelay.v
+      - rtl/ex/wbarbiter.v
+      - rtl/ex/wbdblpriarb.v
+      - rtl/ex/wbpriarbiter.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets: [core]
+
+  lint:
+    default_tool : verilator
+    filesets : [core, ex]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: zipcpu
+
+  sky130_div:
+    default_tool : openlane
+    filesets: [core, sky130]
+    toplevel : div


### PR DESCRIPTION
This adds a core description file for the zipcpu core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register zipcpu as a library in the workspace
fusesoc library add zipcpu /path/to/zipcpu
 #...if repo is available locally or...
fusesoc library add zipcpu https://github.com/zipcpu/zipcpu
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint zipcpu::zipcpu
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 zipcpu::zipcpu
 #List all targets
fusesoc core show zipcpu::zipcpu