### PR TITLE
get second path for verilator

### DIFF
--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -144,7 +144,7 @@ BENCHOBJD:= ../../bench/rtl/obj_dir
 ifneq ($(VERILATOR_ROOT),)
 VERILATOR:=$(VERILATOR_ROOT)/bin/verilator
 else
-VERILATOR_ROOT ?= $(shell bash -c 'verilator -V|grep VERILATOR_ROOT | head -1 | sed -e " s/^.*=\s*//"')
+VERILATOR_ROOT ?= $(shell bash -c 'verilator -V|grep VERILATOR_ROOT | tail -1 | sed -e " s/^.*=\s*//"')
 endif
 export	$(VERILATOR)
 VROOT   := $(VERILATOR_ROOT)


### PR DESCRIPTION
When we run the command `verilator -V`, we see two paths and those paths might be different sometimes. The correct path should be under `Environment` title. Therefore, it might be better to change `head` to `tail`.