### PR TITLE
Remove a duplicated assignment in `dcache`

### DIFF
--- a/rtl/core/dcache.v
+++ b/rtl/core/dcache.v
@@ -912,7 +912,6 @@ module	dcache #(
 		wr_cstb <= 1'b0;
 		last_line_stb <= 1'b0;
 		end_of_line <= 1'b0;
-		state <= DC_IDLE;
 		cyc <= 1'b0;
 		stb <= 1'b0;
 		state <= DC_IDLE;


### PR DESCRIPTION
Thank you for maintaining this project—it's been very helpful to work with.

While reviewing the code, I noticed that an assignment in the reset block of `dcache.v` appears to be duplicated, as it is immediately overwritten:

```verilog
state <= DC_IDLE; // Overwritten below  
cyc <= 1'b0;
stb <= 1'b0;
state <= DC_IDLE; // Effective assignment
```

This pull request removes the initial assignment to `state` to simplify the reset block. This is a minor cleanup and does not introduce any functional changes.

Please feel free to disregard if there's a specific reason for keeping this assignment that I might have missed. Thanks again for your work on this project!